### PR TITLE
v4: first implementation of Slack addon

### DIFF
--- a/dev/__init__.py
+++ b/dev/__init__.py
@@ -1,0 +1,9 @@
+from openpype.addons import BaseServerAddon
+
+from .settings import SlackSettings
+
+
+class SlackAddon(BaseServerAddon):
+    name = "slack"
+    version = "dev"
+    settings_model = SlackSettings

--- a/dev/settings.py
+++ b/dev/settings.py
@@ -1,0 +1,51 @@
+from pydantic import Field
+from openpype.settings.common import BaseSettingsModel
+
+
+class ChannelMessage(BaseSettingsModel):
+    channels: list[str] = Field(default_factory=list, title="Channels")
+    upload_thumbnail: bool = Field(default=True, title="Upload thumbnail")
+    upload_review: bool = Field(default=True, title="Upload review")
+    message: str = Field('', title="Message")
+
+
+class Profile(BaseSettingsModel):
+
+    families: list[str] = Field(default_factory=list, title="Families")
+    hosts: list[str] = Field(default_factory=list, title="Hosts")
+    task_types: str = Field(title="Task types",
+                            enum=["Generic", "Art", "Modeling",
+                                  "Texture", "Lookdev", "Rigging",
+                                  "Edit", "Layout", "Setdress",
+                                  "Animation", "FX", "Lighting",
+                                  "Paint", "Compositing"])
+    task_names: list[str] = Field(default_factory=list, title="Task names")
+    subset_names: list[str] = Field(default_factory=list, title="Subset names")
+    review_upload_limit: int = Field(50,
+                                     title="Upload review maximum "
+                                           "file size (MB)")
+
+    desc = ("Message sent to channel selected by profile. "
+           "Message template can contain {} placeholders from anatomyData "
+           "or {review_filepath} for too large review files to link only.")
+    channel_messages: list[ChannelMessage] = Field(
+        default_factory=list,
+        title="Messages to channels",
+        description=desc,
+        section="Messages",
+        widget="textarea"
+    )
+
+
+class SlackSettings(BaseSettingsModel):
+    """Slack system settings."""
+    enabled: bool = Field(default=True)
+    token: str = Field("", title="Auth Token")
+
+    profiles: list[Profile] = Field(
+        default_factory=list,
+        title="Profiles",
+        description="Profile and message of Slack notification",
+        section="Profiles",
+    )
+

--- a/dev/settings.py
+++ b/dev/settings.py
@@ -25,13 +25,13 @@ class Profile(BaseSettingsModel):
                                      title="Upload review maximum "
                                            "file size (MB)")
 
-    desc = ("Message sent to channel selected by profile. "
-           "Message template can contain {} placeholders from anatomyData "
-           "or {review_filepath} for too large review files to link only.")
+    _desc = ("Message sent to channel selected by profile. "
+             "Message template can contain {} placeholders from anatomyData "
+             "or {review_filepath} for too large review files to link only.")
     channel_messages: list[ChannelMessage] = Field(
         default_factory=list,
         title="Messages to channels",
-        description=desc,
+        description=_desc,
         section="Messages",
         widget="textarea"
     )


### PR DESCRIPTION
Implemented setting according to current state of existing widgets 
(TaskType should be enum pulled from DB, not static; list vs regular)

This repo should be cloned into `openpype4-stack/openpype4-backend/addons/slack`

![v4_slack_settings](https://user-images.githubusercontent.com/4457962/181227291-6cb3cf03-90f1-4c16-9613-5e3254a24403.png)

